### PR TITLE
Corrected input sequence

### DIFF
--- a/demo/simple_example.py
+++ b/demo/simple_example.py
@@ -33,7 +33,7 @@ timestamps = [0, 60, 60]
 # call Kernel
 kernel = TDKernelDMVW(min_x, min_y, max_x, max_y, cell_size, kernel_size, wind_scale, time_scale,
                       low_confidence_calculation_zero=True, evaluation_radius=evaluation_radius)
-kernel.set_measurements(positions_x, positions_y, concentrations, timestamps, wind_speeds, wind_directions)
+kernel.set_measurements(positions_x, positions_y, concentrations, wind_speeds, wind_directions, timestamps)
 kernel.calculate_maps()
 
 # Show result as map

--- a/demo/simple_example.py
+++ b/demo/simple_example.py
@@ -33,7 +33,7 @@ timestamps = [0, 60, 60]
 # call Kernel
 kernel = TDKernelDMVW(min_x, min_y, max_x, max_y, cell_size, kernel_size, wind_scale, time_scale,
                       low_confidence_calculation_zero=True, evaluation_radius=evaluation_radius)
-kernel.set_measurements(positions_x, positions_y, concentrations, wind_speeds, wind_directions, timestamps)
+kernel.set_measurements(positions_x, positions_y, concentrations, timestamps, wind_speeds, wind_directions)
 kernel.calculate_maps()
 
 # Show result as map

--- a/kernel/td_kernel_dmvw.py
+++ b/kernel/td_kernel_dmvw.py
@@ -168,7 +168,7 @@ class TDKernelDMVW(object):
             self.importance_weight_concentration_map[low_index_x:high_index_x, low_index_y:high_index_y] += omega * self.measurement_concentrations[i]
 
         # alpha
-        self.confidence_map = 1 - np.exp(-self.importance_weight_map / (self.sigma_omega * self.sigma_omega))
+        self.confidence_map = 1 - np.exp(-(self.importance_weight_map)**2 / (self.sigma_omega * self.sigma_omega))
 
         # r_0
         if self.low_confidence_calculation_zero:

--- a/kernel/td_kernel_dmvw.py
+++ b/kernel/td_kernel_dmvw.py
@@ -168,7 +168,7 @@ class TDKernelDMVW(object):
             self.importance_weight_concentration_map[low_index_x:high_index_x, low_index_y:high_index_y] += omega * self.measurement_concentrations[i]
 
         # alpha
-        self.confidence_map = 1 - np.exp(-(self.importance_weight_map)**2 / (self.sigma_omega * self.sigma_omega))
+        self.confidence_map = 1 - np.exp(-self.importance_weight_map / (self.sigma_omega * self.sigma_omega))
 
         # r_0
         if self.low_confidence_calculation_zero:


### PR DESCRIPTION
It seems the values in kernel.set_measurements(...)[simple_example.py, 36] were not added in the correct sequence.
