### PR TITLE
Bugfix__Correct input of min_y&min_x

### DIFF
--- a/kernel/td_kernel_dmvw.py
+++ b/kernel/td_kernel_dmvw.py
@@ -144,8 +144,8 @@ class TDKernelDMVW(object):
 
             norm_fact = 1 / (2 * np.pi * sigma_x * sigma_y * np.sqrt(1 - rho ** 2))
 
-            min_y = round((x-self.min_x)/self.cell_size, 0)
-            min_x = round((y-self.min_y)/self.cell_size, 0)
+            min_x = round((x-self.min_x)/self.cell_size, 0)
+            min_y = round((y-self.min_y)/self.cell_size, 0)
 
             count_cells = self.evaluation_radius * self.kernel_size / self.cell_size
             low_index_x = int(np.max([0, min_x-count_cells]))
@@ -201,8 +201,8 @@ class TDKernelDMVW(object):
             concentration = self.measurement_concentrations[i]
             timestamp = self.measurement_timestamps[i]
 
-            min_y = int(round((self.measurement_positions_x[i] - self.min_x) / self.cell_size, 0))
-            min_x = int(round((self.measurement_positions_y[i] - self.min_y) / self.cell_size, 0))
+            min_x = int(round((self.measurement_positions_x[i] - self.min_x) / self.cell_size, 0))
+            min_y = int(round((self.measurement_positions_y[i] - self.min_y) / self.cell_size, 0))
 
             count_cells = self.evaluation_radius * self.kernel_size / self.cell_size
             low_index_x = int(np.max([0, min_x - count_cells]))

--- a/kernel/td_kernel_dmvw.py
+++ b/kernel/td_kernel_dmvw.py
@@ -144,8 +144,8 @@ class TDKernelDMVW(object):
 
             norm_fact = 1 / (2 * np.pi * sigma_x * sigma_y * np.sqrt(1 - rho ** 2))
 
-            min_x = round((x-self.min_x)/self.cell_size, 0)
-            min_y = round((y-self.min_y)/self.cell_size, 0)
+            min_y = round((x-self.min_x)/self.cell_size, 0)
+            min_x = round((y-self.min_y)/self.cell_size, 0)
 
             count_cells = self.evaluation_radius * self.kernel_size / self.cell_size
             low_index_x = int(np.max([0, min_x-count_cells]))
@@ -201,8 +201,8 @@ class TDKernelDMVW(object):
             concentration = self.measurement_concentrations[i]
             timestamp = self.measurement_timestamps[i]
 
-            min_x = int(round((self.measurement_positions_x[i] - self.min_x) / self.cell_size, 0))
-            min_y = int(round((self.measurement_positions_y[i] - self.min_y) / self.cell_size, 0))
+            min_y = int(round((self.measurement_positions_x[i] - self.min_x) / self.cell_size, 0))
+            min_x = int(round((self.measurement_positions_y[i] - self.min_y) / self.cell_size, 0))
 
             count_cells = self.evaluation_radius * self.kernel_size / self.cell_size
             low_index_x = int(np.max([0, min_x - count_cells]))


### PR DESCRIPTION
Hi,
I apologize for opening and closing this pull request xD

It seems that there was a typo. This causes a error when trying to set different min_x and min_y(for eg. min_x = 5, min_y=0).
I am not entirely sure if this fixes the problem, but I think its a step into the right direction.

If I am mistaken I apologize in advance!

Kind regards,
E